### PR TITLE
Add Dockerfile and usage docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Ignore real SDK tarballs
+MrSID_DSDK*.tar.gz
+# Keep placeholder
+!mrsid_sdk_placeholder.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.10-slim
+
+ARG MRSID_SDK_PATH=mrsid_sdk_placeholder.tar.gz
+
+# Install GDAL
+RUN apt-get update \ 
+    && apt-get install -y gdal-bin libgdal-dev \ 
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy test script
+WORKDIR /app
+COPY sidtest.py /app/sidtest.py
+
+# Optionally install MrSID SDK
+COPY ${MRSID_SDK_PATH} /tmp/mrsid_sdk.tar.gz
+RUN if [ -s /tmp/mrsid_sdk.tar.gz ]; then \
+        mkdir -p /opt/mrsid && \
+        tar -xzf /tmp/mrsid_sdk.tar.gz -C /opt/mrsid --strip-components=1 && \
+        rm /tmp/mrsid_sdk.tar.gz && \
+        echo "MrSID SDK installed"; \
+    else \
+        echo "MrSID SDK not provided" && rm /tmp/mrsid_sdk.tar.gz; \
+    fi
+
+ENV PATH="/opt/mrsid/bin:${PATH}"
+
+ENTRYPOINT ["python", "/app/sidtest.py"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # arlcleaner
+
 Full AI gen MrSID and Tiff Processor
+
+## Building the Docker image
+
+The repository includes a `Dockerfile` that installs Python 3 and GDAL.  The proprietary MrSID SDK can be added at build time when you have downloaded the archive separately.
+
+Download the SDK from LizardTech and place the tarball in this directory (the filename used below matches the current release).
+
+### Without the SDK
+
+Build a basic image that only contains GDAL:
+
+```bash
+docker build -t arlcleaner .
+```
+
+### Including the MrSID SDK
+
+Copy the SDK archive into the project root and pass its name via the `MRSID_SDK_PATH` build argument:
+
+```bash
+cp /mnt/rawdata/pyarl/SID/MrSID_DSDK-9.5.4.4709-rhel6.x86-64.gcc531.tar.gz .
+docker build --build-arg MRSID_SDK_PATH=MrSID_DSDK-9.5.4.4709-rhel6.x86-64.gcc531.tar.gz -t arlcleaner .
+```
+
+Alternatively, you can place the archive elsewhere and reference the relative path when building.
+
+## Running
+
+The container executes `sidtest.py` by default.  To run it:
+
+```bash
+docker run --rm arlcleaner
+```
+
+The script reports the GDAL version and whether the MrSID SDK is available.

--- a/sidtest.py
+++ b/sidtest.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+
+def main():
+    print("Running sidtest.py")
+    try:
+        subprocess.run(["gdalinfo", "--version"], check=True)
+    except Exception as e:
+        print("GDAL not available:", e)
+    if os.path.exists("/opt/mrsid"):
+        print("MrSID SDK installed")
+    else:
+        print("MrSID SDK not installed")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add docker build with optional MrSID install
- ignore SDK tarballs and add placeholder
- add sidtest script
- document Docker build and usage

## Testing
- `git status --short`
- *Docker not installed: `docker` command not found*

------
https://chatgpt.com/codex/tasks/task_e_68503fbe5aa4832f89f1efdff35df980