### PR TITLE
Add script and Dockerfile for MrSID SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # arlcleaner
 
-Full AI gen MrSID and Tiff Processor
+Tools for converting MrSID and GeoTIFF imagery inside a container.
 
 ## Building the Docker image
 
-The repository includes a `Dockerfile` that installs Python 3 and GDAL.  The proprietary MrSID SDK can be added at build time when you have downloaded the archive separately.
+The Docker image installs Python, GDAL and, optionally, the proprietary MrSID SDK.  Because the SDK cannot be redistributed, download the tarball separately and place it in this directory before building.
 
 Download the SDK from LizardTech and place the tarball in this directory (the filename used below matches the current release).
 
@@ -36,3 +36,14 @@ docker run --rm arlcleaner
 ```
 
 The script reports the GDAL version and whether the MrSID SDK is available.
+
+### Converting SID files
+
+When the SDK is included, you can convert a `.sid` file to a GeoJPEG using the helper script:
+
+```bash
+docker run --rm -v /path/to/data:/data arlcleaner \
+    decode_sid.sh /data/input.sid
+```
+
+This produces `input.jpg` and `input.jgw` alongside the source file.

--- a/decode_sid.sh
+++ b/decode_sid.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Simple wrapper to convert a MrSID file to GeoJPEG inside the container.
+# Usage: decode_sid.sh /path/to/input.sid
+
+sid=$1
+if [ -z "$sid" ]; then
+    echo "Usage: decode_sid.sh <file.sid>"
+    exit 1
+fi
+
+jpg="${sid%.sid}.jpg"
+
+mrsidgeodecode -i "$sid" -o temp.tif -of tifg -wf
+
+gdal_translate temp.tif "$jpg" -of JPEG -co WORLDFILE=YES -co QUALITY=90 -co TILED=YES
+
+rm temp.tif
+
+echo "Finished -> $jpg (+ .jgw)"

--- a/sidtest.py
+++ b/sidtest.py
@@ -1,4 +1,4 @@
-import os
+import shutil
 import subprocess
 
 def main():
@@ -7,10 +7,20 @@ def main():
         subprocess.run(["gdalinfo", "--version"], check=True)
     except Exception as e:
         print("GDAL not available:", e)
-    if os.path.exists("/opt/mrsid"):
-        print("MrSID SDK installed")
+
+    if shutil.which("mrsidgeodecode"):
+        print("mrsidgeodecode available")
     else:
-        print("MrSID SDK not installed")
+        print("mrsidgeodecode not found")
+
+    try:
+        out = subprocess.check_output(["gdalinfo", "--formats"], text=True)
+        if "MrSID" in out:
+            print("GDAL reports MrSID support")
+        else:
+            print("GDAL does not report MrSID support")
+    except Exception as e:
+        print("Could not query GDAL formats:", e)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- base Dockerfile on Ubuntu 24.04
- install optional MrSID SDK from provided tarball
- add helper script `decode_sid.sh` for converting SID files
- expand README with build and usage instructions
- enhance `sidtest.py` to check for command availability

## Testing
- `python3 -m py_compile sidtest.py`

------
https://chatgpt.com/codex/tasks/task_e_68503d9bb900832f8b891d6a018da230