### PR TITLE
Add sid-test Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+IMAGE_NAME ?= arlcleaner
+MRSID_SDK_PATH ?= mrsid_sdk_placeholder.tar.gz
+
+.PHONY: build
+build:
+	docker build --build-arg MRSID_SDK_PATH=$(MRSID_SDK_PATH) -t $(IMAGE_NAME) .
+
+.PHONY: sid-test
+sid-test: build
+	docker run --rm $(IMAGE_NAME)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ The container executes `sidtest.py` by default.  To run it:
 docker run --rm arlcleaner
 ```
 
+Alternatively, you can build the image and run the test via `make`:
+
+```bash
+make sid-test
+```
+
 The script reports the GDAL version and whether the MrSID SDK is available.
 
 ### Converting SID files


### PR DESCRIPTION
## Summary
- add Makefile with `sid-test` target that builds the Docker image and runs `sidtest.py`
- document `make sid-test` usage in README

## Testing
- `make sid-test` *(fails: docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6850511207ec832fb28c205e78afcb31