### PR TITLE
Improve EPSG handling and keep original inputs

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,3 +7,16 @@ SID_INPUT = DATA_ROOT + '/TestSIDInput'
 SID_OUTPUT = DATA_ROOT + '/TestSIDOutput'
 TIFF_INPUT = DATA_ROOT + '/TestTIFFInput'
 TIFF_OUTPUT = DATA_ROOT + '/TestTIFFOutput'
+
+# Where to store logs for failed conversions
+ERROR_LOGS = DATA_ROOT + '/ErrorLogs'
+
+# Directory where files that fail processing are moved
+FAILED_PROCESSING = DATA_ROOT + '/FailedProcessing'
+
+# Quality for JPEG compression when converting imagery
+JPEG_QUALITY = 90
+
+# Pixel dimensions for SID tiling
+SID_TILE_WIDTH = 5000
+SID_TILE_HEIGHT = 5000

--- a/image_test.py
+++ b/image_test.py
@@ -21,8 +21,9 @@ def main() -> None:
     for src in _iter_files(config.SID_INPUT, [".sid"]):
         print(f"Processing SID: {src}")
         try:
-            dst = process_sid(src, config.SID_OUTPUT)
-            print(f"  -> {dst}")
+            dst_files = process_sid(src, config.SID_OUTPUT)
+            for d in dst_files:
+                print(f"  -> {d}")
         except Exception as e:
             print(f"Failed to process {src}: {e}")
 


### PR DESCRIPTION
## Summary
- suppress GDAL command output and parse EPSG reliably
- copy failed images instead of moving them
- run gdalwarp in quiet mode

## Testing
- `python3 -m py_compile convert.py image_test.py`
- `python3 image_test.py` *(fails: FileNotFoundError)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68507f3c731c832f930c635dce537f18