### PR TITLE
Improve CRS detection and fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,7 @@ The input and output folders used by `test-image` can be adjusted in `config.py`
 ## Configuration
 `config.py` defines runtime options such as JPEG quality, tile size for SID images, the number of parallel workers, and whether to enforce a geographic bounding‑box check.  Adjust these settings to match your dataset and hardware.
 
+The conversion helpers attempt to read the input image's spatial reference via `gdalinfo` and any accompanying `.aux.xml` file.  If no EPSG code can be determined, the tools still create a JPEG but only keep it when the resulting bounding box falls inside a reasonable range.
+
 ---
 After building, run one of the make commands above to start converting imagery.


### PR DESCRIPTION
## Summary
- parse `.aux.xml` files when present to get CRS
- fall back to JPEG conversion even when EPSG can't be found, keeping result only if bbox is reasonable
- document CRS detection approach in README

## Testing
- `python3 -m py_compile convert.py image_test.py sidtest.py`
- `python3 image_test.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685181b33394832f89993e782ccd727a